### PR TITLE
Update password reset with unified input

### DIFF
--- a/family-events/prisma/migrations/20251007_0002_drop_user_username.sql
+++ b/family-events/prisma/migrations/20251007_0002_drop_user_username.sql
@@ -1,0 +1,3 @@
+-- Drop username column from User table (safe if it already doesn't exist)
+ALTER TABLE "User" DROP COLUMN IF EXISTS "username";
+

--- a/family-events/prisma/schema.prisma
+++ b/family-events/prisma/schema.prisma
@@ -23,7 +23,6 @@ model User {
   id        String   @id @default(cuid())
   name      String?
   email     String?  @unique
-  username  String?  @unique
   image     String?
   role      String   @default("member")
   passwordHash String?

--- a/family-events/src/app/api/admin/approvals/route.ts
+++ b/family-events/src/app/api/admin/approvals/route.ts
@@ -15,7 +15,7 @@ async function requireAdmin() {
 export async function GET() {
   const me = await requireAdmin();
   if (!me) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  const users = await prisma.user.findMany({ where: { familyId: me.familyId, approved: false }, select: { id: true, name: true, email: true, username: true, image: true } });
+  const users = await prisma.user.findMany({ where: { familyId: me.familyId, approved: false }, select: { id: true, name: true, email: true, image: true } });
   return NextResponse.json({ users });
 }
 

--- a/family-events/src/app/api/family/groups/route.ts
+++ b/family-events/src/app/api/family/groups/route.ts
@@ -14,12 +14,12 @@ export async function GET(req: Request) {
       if (process.env.VERCEL_ENV === 'preview') {
         const mock = [
           { id: 'g1', nickname: 'הורים', members: [
-            { id: 'u1', name: 'אבא', image: null, username: 'dad' },
-            { id: 'u2', name: 'אמא', image: null, username: 'mom' },
+            { id: 'u1', name: 'אבא', image: null },
+            { id: 'u2', name: 'אמא', image: null },
           ]},
           { id: 'g2', nickname: 'ילדים', members: [
-            { id: 'u3', name: 'דני', image: null, username: 'dani' },
-            { id: 'u4', name: 'נועה', image: null, username: 'noa' },
+            { id: 'u3', name: 'דני', image: null },
+            { id: 'u4', name: 'נועה', image: null },
           ]},
         ];
         return NextResponse.json({ groups: mock });
@@ -28,7 +28,7 @@ export async function GET(req: Request) {
     }
     const groups = await prisma.group.findMany({
       where: { familyId: family.id },
-      include: { members: { select: { id: true, name: true, image: true, username: true } }, parent: { select: { id: true, nickname: true } } },
+      include: { members: { select: { id: true, name: true, image: true } }, parent: { select: { id: true, nickname: true } } },
       orderBy: { createdAt: 'asc' },
     });
     return NextResponse.json({ groups });
@@ -39,7 +39,7 @@ export async function GET(req: Request) {
   if (!user?.familyId) return NextResponse.json({ groups: [] });
   const groups = await prisma.group.findMany({
     where: { familyId: user.familyId },
-    include: { members: { select: { id: true, name: true, image: true, username: true } }, parent: { select: { id: true, nickname: true } } },
+    include: { members: { select: { id: true, name: true, image: true } }, parent: { select: { id: true, nickname: true } } },
     orderBy: { createdAt: 'asc' },
   });
   return NextResponse.json({ groups });

--- a/family-events/src/app/api/users/check-username/route.ts
+++ b/family-events/src/app/api/users/check-username/route.ts
@@ -1,11 +1,7 @@
+// Deprecated: username is no longer used. Keep route for backward compatibility.
 import { NextResponse } from 'next/server';
-import { prisma } from '@/lib/prisma';
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const u = (searchParams.get('u') || '').toLowerCase().trim();
-  if (!u) return NextResponse.json({ available: false });
-  const existing = await prisma.user.findFirst({ where: { username: u } });
-  return NextResponse.json({ available: !existing });
+export async function GET() {
+  return NextResponse.json({ available: true });
 }
 

--- a/family-events/src/app/events/new/page.tsx
+++ b/family-events/src/app/events/new/page.tsx
@@ -176,7 +176,7 @@ function GuestSelector() {
   'use client';
   const [loading, setLoading] = useState(true);
   const [me, setMe] = useState<{ id: string; groupId: string | null } | null>(null);
-  const [groups, setGroups] = useState<{ id: string; nickname: string; members: { id: string; name: string | null; image: string | null; username: string | null }[] }[]>([]);
+  const [groups, setGroups] = useState<{ id: string; nickname: string; members: { id: string; name: string | null; image: string | null }[] }[]>([]);
   const [selected, setSelected] = useState<Record<string, boolean>>({});
   const [selectedGroups, setSelectedGroups] = useState<Record<string, boolean>>({});
 
@@ -238,8 +238,8 @@ function GuestSelector() {
               {g.members.map((u) => (
                 <label key={u.id} className={`inline-flex items-center gap-2 px-2 py-1 rounded border text-sm ${selected[u.id] ? 'bg-blue-50 border-blue-300' : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800'}`}>
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src={u.image && u.image.startsWith('http') ? u.image : `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(u.username || u.name || 'user')}`} alt={u.name || u.username || ''} className="w-5 h-5" />
-                  <span>{u.name || u.username}</span>
+                  <img src={u.image && u.image.startsWith('http') ? u.image : `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(u.name || 'user')}`} alt={u.name || ''} className="w-5 h-5" />
+                  <span>{u.name || ''}</span>
                   <input type="checkbox" className="ml-1" checked={!!selected[u.id]} onChange={() => toggleUser(u.id)} />
                 </label>
               ))}

--- a/family-events/src/app/forgot/page.tsx
+++ b/family-events/src/app/forgot/page.tsx
@@ -1,46 +1,62 @@
 "use client";
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 
 export default function ForgotPage() {
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
-  const [name, setName] = useState('');
-  const [sent, setSent] = useState<string | null>(null);
+  const router = useRouter();
+  const [identifier, setIdentifier] = useState('');
   const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
   async function submit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
-    setMessage('');
+    setError('');
     try {
-      const payload: any = {};
-      if (username.trim()) payload.username = username.trim();
-      if (!username.trim()) {
-        payload.email = email.trim();
-        payload.name = name.trim();
+      const id = identifier.trim();
+      if (!id) return;
+      const res = await fetch('/api/auth/forgot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier: id }),
+      });
+      if (res.ok) {
+        // Navigate away so we don't remain on the reset request screen
+        router.replace('/signin');
+        return;
       }
-      const res = await fetch('/api/auth/forgot', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
-      const j = await res.json().catch(() => ({ ok: false }));
-      setSent(j.link ?? null);
-      setMessage('אם החשבון קיים, שלחנו קישור לאיפוס לאימייל.');
+      if (res.status === 404) {
+        setError(`לא נמצא משתמש עבור: ${id}`);
+        return;
+      }
+      setError('אירעה שגיאה בשליחת הקישור. נסו שוב.');
     } catch {
-      setMessage('אירעה שגיאה בשליחת הקישור. נסו שוב.');
+      setError('אירעה שגיאה בשליחת הקישור. נסו שוב.');
     } finally {
       setLoading(false);
     }
   }
+
   return (
     <main className="container-page max-w-md mx-auto space-y-4">
-      <h1 className="text-2xl font-bold">שכחת סיסמה</h1>
+      <h1 className="text-2ל font-bold">שכחת סיסמה</h1>
+      {error && <div className="text-sm text-red-600">{error}</div>}
       <form onSubmit={submit} className="space-y-2">
-        <input autoComplete="username" className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none" placeholder="שם משתמש (חלופי)" value={username} onChange={e=>setUsername(e.target.value)} />
-        <div className="text-xs text-gray-500">או הזינו שם + אימייל כדי לזהות משתמש במקרה של אימייל משותף</div>
-        <input autoComplete="email" className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none" placeholder="אימייל" value={email} onChange={e=>setEmail(e.target.value)} />
-        <input className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none" placeholder="שם מלא" value={name} onChange={e=>setName(e.target.value)} />
-        <button type="submit" disabled={loading || (!username.trim() && (!email.trim() || !name.trim()))} className="w-full px-3 py-2 bg-blue-600 text-white rounded disabled:opacity-50 disabled:cursor-not-allowed">{loading ? 'שולח…' : 'שלח קישור לאיפוס'}</button>
+        <input
+          autoComplete="username"
+          className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none"
+          placeholder="שם משתמש או אימייל"
+          value={identifier}
+          onChange={e => setIdentifier(e.target.value)}
+        />
+        <button
+          type="submit"
+          disabled={loading || !identifier.trim()}
+          className="w-full px-3 py-2 bg-blue-600 text-white rounded disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? 'שולח…' : 'שלח קישור לאיפוס'}
+        </button>
       </form>
-      {message && <div className="text-sm text-gray-700 dark:text-gray-300">{message}</div>}
-      {sent && <div className="text-sm text-gray-600 break-all">קישור (לבדיקות): {sent}</div>}
     </main>
   );
 }

--- a/family-events/src/app/forgot/page.tsx
+++ b/family-events/src/app/forgot/page.tsx
@@ -39,11 +39,11 @@ export default function ForgotPage() {
 
   return (
     <main className="container-page max-w-md mx-auto space-y-4">
-      <h1 className="text-2ל font-bold">שכחת סיסמה</h1>
+      <h1 className="text-2xl font-bold">שכחת סיסמה</h1>
       {error && <div className="text-sm text-red-600">{error}</div>}
       <form onSubmit={submit} className="space-y-2">
         <input
-          autoComplete="username"
+          autoComplete="email"
           className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none"
           placeholder="שם משתמש או אימייל"
           value={identifier}

--- a/family-events/src/app/onboarding/group/page.tsx
+++ b/family-events/src/app/onboarding/group/page.tsx
@@ -30,7 +30,7 @@ export default async function OnboardingGroupPage() {
   const groups = await prisma.group.findMany({
     where: { familyId: me.familyId },
     orderBy: { createdAt: 'asc' },
-    include: { members: { select: { id: true, name: true, username: true, image: true } }, parent: { select: { id: true, nickname: true } } },
+    include: { members: { select: { id: true, name: true, image: true } }, parent: { select: { id: true, nickname: true } } },
   });
 
   async function setGroup(formData: FormData) {
@@ -74,8 +74,8 @@ export default async function OnboardingGroupPage() {
                       {g.members.slice(0, 6).map((m) => (
                         <span key={m.id} className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-800 rounded text-xs">
                           {/* eslint-disable-next-line @next/next/no-img-element */}
-                          <img src={resolveUserAvatar(m.image, m.username, m.name)} alt={m.name || m.username || ''} className="w-4 h-4" />
-                          <span>{m.name || m.username}</span>
+                          <img src={resolveUserAvatar(m.image, m.name)} alt={m.name || ''} className="w-4 h-4" />
+                          <span>{m.name || ''}</span>
                         </span>
                       ))}
                       {g.members.length > 6 && (
@@ -109,9 +109,9 @@ export default async function OnboardingGroupPage() {
   );
 }
 
-function resolveUserAvatar(image: string | null | undefined, username?: string | null, name?: string | null) {
+function resolveUserAvatar(image: string | null | undefined, name?: string | null) {
   if (image && image.startsWith('http')) return image;
-  const seed = username || name || 'user';
+  const seed = name || 'user';
   return `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(seed)}`;
 }
 

--- a/family-events/src/app/settings/page.tsx
+++ b/family-events/src/app/settings/page.tsx
@@ -112,9 +112,9 @@ async function getMembers(familyId: string) {
 
 async function getApprovals() {
   const res = await fetch(`${process.env.NEXTAUTH_URL ?? ''}/api/admin/approvals`, { cache: 'no-store' });
-  if (!res.ok) return [] as { id: string; name: string | null; email: string | null; username: string | null; image: string | null }[];
+  if (!res.ok) return [] as { id: string; name: string | null; email: string | null; image: string | null }[];
   const j = await res.json();
-  return j.users as { id: string; name: string | null; email: string | null; username: string | null; image: string | null }[];
+  return j.users as { id: string; name: string | null; email: string | null; image: string | null }[];
 }
 
 async function Approvals({ familyId, isAdmin }: { familyId: string | null; isAdmin: boolean }) {
@@ -131,7 +131,7 @@ async function Approvals({ familyId, isAdmin }: { familyId: string | null; isAdm
       <ul className="space-y-1">
         {users.map(u => (
           <li key={u.id} className="flex items-center justify-between text-sm">
-            <span>{u.name ?? u.username ?? u.email ?? u.id}</span>
+            <span>{u.name ?? u.email ?? u.id}</span>
             <div className="flex gap-2">
               <form action={async ()=>act(u.id,'approve')}><button className="px-2 py-1 border rounded">אישור</button></form>
               <form action={async ()=>act(u.id,'deny')}><button className="px-2 py-1 border rounded">דחייה</button></form>

--- a/family-events/src/app/signin/page.tsx
+++ b/family-events/src/app/signin/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 export default function SignInPage() {
   const router = useRouter();
   const { status } = useSession();
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<'login' | null>(null);
 
@@ -17,12 +17,12 @@ export default function SignInPage() {
     try {
       setLoading('login');
       const pwd = (e.target as HTMLFormElement).password.value as string;
-      const res = await signIn('credentials', { username, password: pwd, redirect: false });
+      const res = await signIn('credentials', { email, password: pwd, redirect: false });
       if (res?.ok) {
         router.replace('/events');
         return;
       }
-      setError('שם משתמש/כינוי או סיסמה שגויים');
+      setError('אימייל או סיסמה שגויים');
     } catch (e) {
       alert('אירעה שגיאה בתהליך הכניסה');
       setLoading(null);
@@ -44,9 +44,9 @@ export default function SignInPage() {
         <a href="/forgot" className="text-blue-600">שכחת סיסמה?</a>
       </div>
       <form onSubmit={signInEmail} className="space-y-2">
-        <input autoComplete="username" className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none dark:[-webkit-text-fill-color:#e5e7eb]" name="username" placeholder="שם משתמש / כינוי" value={username} onChange={(e)=>setUsername(e.target.value)} />
+        <input autoComplete="email" className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none dark:[-webkit-text-fill-color:#e5e7eb]" name="email" placeholder="אימייל" value={email} onChange={(e)=>setEmail(e.target.value)} />
         <input autoComplete="current-password" className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 appearance-none dark:[-webkit-text-fill-color:#e5e7eb]" name="password" type="password" placeholder="סיסמה" />
-        <button disabled={!username || loading === 'login'} className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-800 dark:text-gray-100 rounded">
+        <button disabled={!email || loading === 'login'} className="w-full px-3 py-2 bg-gray-200 dark:bg-gray-800 dark:text-gray-100 rounded">
           {loading === 'login' ? 'שולח…' : 'כניסה'}
         </button>
       </form>

--- a/family-events/src/auth.ts
+++ b/family-events/src/auth.ts
@@ -12,14 +12,14 @@ export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       name: 'Credentials',
-      credentials: { username: { label: 'Username', type: 'text' }, password: { label: 'Password', type: 'password' } },
+      credentials: { email: { label: 'Email', type: 'text' }, password: { label: 'Password', type: 'password' } },
       async authorize(credentials) {
-        const rawId = (credentials?.username as string | undefined)?.trim();
-        const username = rawId?.toLowerCase();
+        const rawId = (credentials?.email as string | undefined)?.trim();
+        const email = rawId?.toLowerCase();
         const password = credentials?.password as string | undefined;
         if (!rawId || !password) return null;
-        // Allow login by username or name (no email or phone to match DB)
-        const user = await prisma.user.findFirst({ where: { OR: [ { username }, { name: username } ] } as any });
+        // Email-only login
+        const user = await prisma.user.findFirst({ where: { email: { equals: email, mode: 'insensitive' } as any } as any });
         if (!user?.passwordHash) return null;
         const ok = await bcrypt.compare(password, user.passwordHash);
         return ok ? user : null;

--- a/family-events/src/components/Nav.tsx
+++ b/family-events/src/components/Nav.tsx
@@ -34,7 +34,7 @@ export default function Nav() {
           {status === 'authenticated' && (
             <span className="hidden sm:inline text-sm text-gray-700 dark:text-gray-200 mr-2">
               {(() => {
-                const name = (session?.user as any)?.name || (session?.user as any)?.username || '';
+                const name = (session?.user as any)?.name || '';
                 const first = String(name).trim().split(' ')[0] || '';
                 const h = new Date().getHours();
                 const g = h < 5 ? 'לילה טוב' : h < 12 ? 'בוקר טוב' : h < 18 ? 'צהריים טובים' : 'ערב טוב';

--- a/family-events/src/components/SignupForm.tsx
+++ b/family-events/src/components/SignupForm.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation';
 export default function SignupForm({ initialCode }: { initialCode: string }) {
   const router = useRouter();
   const [code] = useState(initialCode);
-  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('');
@@ -15,7 +14,7 @@ export default function SignupForm({ initialCode }: { initialCode: string }) {
   const [customSeed, setCustomSeed] = useState<string>('custom');
   const [groupId, setGroupId] = useState<string>('');
   const [newGroup, setNewGroup] = useState('');
-  const [groups, setGroups] = useState<{ id: string; nickname: string; members?: { id: string; name: string | null; image: string | null; username: string | null }[] }[]>([]);
+  const [groups, setGroups] = useState<{ id: string; nickname: string; members?: { id: string; name: string | null; image: string | null }[] }[]>([]);
   const [loading, setLoading] = useState(false);
   const [isFirst, setIsFirst] = useState(false);
   const [familyName, setFamilyName] = useState('');
@@ -45,10 +44,10 @@ export default function SignupForm({ initialCode }: { initialCode: string }) {
     e.preventDefault();
     setLoading(true);
     try {
-      const res = await fetch('/api/signup', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code, username, password, nickname, icon, groupId: groupId || null, email, imageUrl: imageUrl || null, newGroup: newGroup || null, familyName: isFirst ? familyName : undefined }) });
+      const res = await fetch('/api/signup', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code, password, nickname, icon, groupId: groupId || null, email, imageUrl: imageUrl || null, newGroup: newGroup || null, familyName: isFirst ? familyName : undefined }) });
       if (res.ok) {
         // Try automatic login, then redirect to events
-        const login = await signIn('credentials', { username: (username || nickname).trim(), password, redirect: false });
+        const login = await signIn('credentials', { email: email.trim(), password, redirect: false });
         if (login?.ok) {
           router.replace('/events');
         } else {
@@ -72,25 +71,15 @@ export default function SignupForm({ initialCode }: { initialCode: string }) {
           {isFirst && (
             <input className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500" placeholder="שם משפחה ראשי" value={familyName} onChange={e=>setFamilyName(e.target.value)} />
           )}
-          <input className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500" placeholder="שם משתמש" value={username} onChange={e=>setUsername(e.target.value)} />
           <input className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500" placeholder="סיסמה" type="password" value={password} onChange={e=>setPassword(e.target.value)} />
           <input className="w-full border p-2 rounded bg-white dark:bg-transparent border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500" placeholder="אימייל" value={email} onChange={e=>setEmail(e.target.value)} />
           <div className="flex gap-2 justify-between">
             <span />
             <button className="px-3 py-2 bg-blue-600 text-white rounded" onClick={async ()=>{
               const missing: string[] = [];
-              if (!username.trim()) missing.push('שם משתמש');
               if (!password.trim()) missing.push('סיסמה');
               if (!email.trim()) missing.push('אימייל');
               if (missing.length) { setError(`שדות חסרים: ${missing.join(', ')}`); return; }
-              // Check username availability before proceeding
-              try {
-                const res = await fetch(`/api/users/check-username?u=${encodeURIComponent(username.trim())}`);
-                const j = await res.json();
-                if (!j.available) { setError('שם המשתמש כבר תפוס'); return; }
-              } catch {
-                setError('תקלה בבדיקת שם המשתמש'); return;
-              }
               setError('');
               setStep(2);
             }}>הבא</button>
@@ -159,8 +148,8 @@ export default function SignupForm({ initialCode }: { initialCode: string }) {
                       <div className="flex flex-wrap gap-2 pl-11">
                         {g.members.map(m => (
                           <span key={m.id} className="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded text-xs">
-                            <img src={m.image && m.image.startsWith('http') ? m.image : `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(m.username || m.name || 'user')}`} alt={m.name || m.username || ''} className="w-4 h-4" />
-                            <span>{m.name || m.username}</span>
+                            <img src={m.image && m.image.startsWith('http') ? m.image : `https://api.dicebear.com/9.x/adventurer/svg?seed=${encodeURIComponent(m.name || 'user')}`} alt={m.name || ''} className="w-4 h-4" />
+                            <span>{m.name || ''}</span>
                           </span>
                         ))}
                       </div>


### PR DESCRIPTION
Remove `username` field from the database and application, and update the password reset and authentication flows to be email-only.

This change simplifies the user experience by removing the `username` concept entirely, streamlining password reset to a single email input, and improving the feedback for password reset requests (redirecting on success, showing an error only if the email is not found).

---
<a href="https://cursor.com/background-agent?bcId=bc-97c4ae20-c082-4a5b-8258-6dfe71a53f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97c4ae20-c082-4a5b-8258-6dfe71a53f8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

